### PR TITLE
Refactor test organization - MUI v5 playwright tests (5/n)

### DIFF
--- a/packages/component-driver-mui-v5-dom-test/__tests__/components/SelectComponentDriver.test.tsx
+++ b/packages/component-driver-mui-v5-dom-test/__tests__/components/SelectComponentDriver.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { BasicSelectExample, basicSelectExampleScenePart } from '../../src/examples/Select.examples';
 
-describe('SelectComponentDriver', () => {  
+describe('SelectComponentDriver', () => {
   test('basic select', async () => {
     const testEngine = createTestEngine(<BasicSelectExample />, basicSelectExampleScenePart);
     const targetValue = '30';

--- a/packages/component-driver-mui-v5-dom-test/src/examples/Select.examples.tsx
+++ b/packages/component-driver-mui-v5-dom-test/src/examples/Select.examples.tsx
@@ -44,5 +44,5 @@ export const selectExamples = [
     title: 'Basic Select',
     scene: basicSelectExampleScenePart,
     ui: <BasicSelectExample />,
-  }
+  },
 ] satisfies IExampleUnit<ScenePart, JSX.Element>[];

--- a/packages/component-driver-mui-v5-playwright-test/README.md
+++ b/packages/component-driver-mui-v5-playwright-test/README.md
@@ -1,0 +1,1 @@
+# @testzilla/playwright

--- a/packages/component-driver-mui-v5-playwright-test/__tests__/SelectComponentDriver.test.ts
+++ b/packages/component-driver-mui-v5-playwright-test/__tests__/SelectComponentDriver.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { SelectComponentDriver } from '@testzilla/component-driver-mui-v5';
+import { byDataTestId, ScenePart } from '@testzilla/core';
+
+import { createTestEngine } from '../src/createTestEngine';
+
+const testScenePart = {
+  select: {
+    locator: byDataTestId('demo-simple-select'),
+    driver: SelectComponentDriver,
+  },
+} satisfies ScenePart;
+
+test('happy path selection', async ({ page }) => {
+  await page.goto('http://testzilla-mui-v5.s3-website-us-east-1.amazonaws.com/select');
+  const testEngine = createTestEngine(page, testScenePart);
+  const targetValue = '30';
+  await testEngine.parts.select.setValue(targetValue);
+  const val = await testEngine.parts.select.getValue();
+  expect(val).toBe(targetValue);
+});

--- a/packages/component-driver-mui-v5-playwright-test/package.json
+++ b/packages/component-driver-mui-v5-playwright-test/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@testzilla/playwright",
+  "name": "component-driver-mui-v5-playwright-test",
+  "private": true,
   "version": "0.0.0",
-  "description": "TestZilla Playwright Adapter",
+  "description": "MUI v5 Testzilla component driver tests in Playwright",
   "main": "dist/index.js",
   "files": [
     "dist",
     "src"
   ],
   "scripts": {
-    "build": "tsc",
-    "postbuild": "node ../../scripts/postBuild.js"
+    "test": "playwright test"
   },
   "author": "Tianzhen Lin <tangent@usa.net>",
   "keywords": [],
@@ -18,11 +18,12 @@
     "type": "git",
     "url": "https://github.com/tangentlin/testzilla.git"
   },
-  "dependencies": {
-    "@testzilla/core": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@playwright/test": "^1.31.1",
+    "@testzilla/core": "workspace:*",
+    "@testzilla/component-driver-mui-v5": "workspace:*",
+    "@testzilla/playwright": "workspace:*",
     "@types/node": "^16.0.0",
     "jest": "^29.2.0",
     "ts-jest": "^29.0.0",

--- a/packages/component-driver-mui-v5-playwright-test/playwright.config.ts
+++ b/packages/component-driver-mui-v5-playwright-test/playwright.config.ts
@@ -1,0 +1,90 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './__tests__',
+  /* Maximum time one test can run for. */
+  timeout: 3 * 1000, // 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { channel: 'chrome' },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'cd .. && cd e2e-mui-v5 && pnpm start',
+  //   port: 6066,
+  // },
+});

--- a/packages/component-driver-mui-v5-playwright-test/src/PlaywrightInteractor.ts
+++ b/packages/component-driver-mui-v5-playwright-test/src/PlaywrightInteractor.ts
@@ -1,0 +1,33 @@
+import { Page } from '@playwright/test';
+import { IClickOption, IInteractor, LocatorChain, locatorUtil, Optional } from '@testzilla/core';
+
+export class PlaywrightInteractor implements IInteractor {
+  constructor(public readonly page: Page) {}
+
+  async click(locator: LocatorChain, option?: IClickOption): Promise<void> {
+    const cssLocator = locatorUtil.toCssSelector(locator);
+    await this.page.locator(cssLocator).click();
+  }
+
+  async getAttribute(locator: LocatorChain): Promise<Optional<string>> {
+    const cssLocator = locatorUtil.toCssSelector(locator);
+    const value = await this.page.locator(cssLocator).getAttribute('value');
+    return value ?? undefined;
+  }
+
+  async getText(locator: LocatorChain): Promise<Optional<string>> {
+    const cssLocator = locatorUtil.toCssSelector(locator);
+    const text = await this.page.locator(cssLocator).textContent();
+    return text ?? undefined;
+  }
+
+  async exists(locator: LocatorChain): Promise<boolean> {
+    const cssLocator = locatorUtil.toCssSelector(locator);
+    const count = await this.page.locator(cssLocator).count();
+    return count > 0;
+  }
+
+  clone(): IInteractor {
+    return new PlaywrightInteractor(this.page);
+  }
+}

--- a/packages/component-driver-mui-v5-playwright-test/src/createTestEngine.ts
+++ b/packages/component-driver-mui-v5-playwright-test/src/createTestEngine.ts
@@ -1,0 +1,13 @@
+import { Page } from '@playwright/test';
+import { defaultStep, ScenePart, TestEngine } from '@testzilla/core';
+
+import { PlaywrightInteractor } from './PlaywrightInteractor';
+
+export function createTestEngine<T extends ScenePart>(page: Page, partDefinitions: T): TestEngine<T> {
+  const engine = new TestEngine([], new PlaywrightInteractor(page), {
+    perform: defaultStep,
+    parts: partDefinitions,
+  });
+
+  return engine;
+}

--- a/packages/component-driver-mui-v5-playwright-test/src/index.ts
+++ b/packages/component-driver-mui-v5-playwright-test/src/index.ts
@@ -1,0 +1,2 @@
+export { createTestEngine } from './createTestEngine';
+export { PlaywrightInteractor } from './PlaywrightInteractor';

--- a/packages/component-driver-mui-v5-playwright-test/tsconfig.json
+++ b/packages/component-driver-mui-v5-playwright-test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "declaration", "generator-build", "runtime"],
+  "include": ["./src", "__tests__"],
+  "compilerOptions": {
+    "outDir": "./build",
+    "composite": true,
+  },
+  "references": [
+    { "path": "../core" },
+    { "path": "../dom-core" },
+    { "path": "../component-driver-mui-v5" }
+  ],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,28 @@ importers:
       ts-node: 10.9.1_zix2iy4c4a7fivhrc3ey4gy2pu
       typescript: 4.9.5
 
+  packages/component-driver-mui-v5-playwright-test:
+    specifiers:
+      '@playwright/test': ^1.31.1
+      '@testzilla/component-driver-mui-v5': workspace:*
+      '@testzilla/core': workspace:*
+      '@testzilla/playwright': workspace:*
+      '@types/node': ^16.0.0
+      jest: ^29.2.0
+      ts-jest: ^29.0.0
+      ts-node: ^10.9.0
+      typescript: ^4.9.0
+    devDependencies:
+      '@playwright/test': 1.31.1
+      '@testzilla/component-driver-mui-v5': link:../component-driver-mui-v5
+      '@testzilla/core': link:../core
+      '@testzilla/playwright': link:../playwright
+      '@types/node': 16.18.14
+      jest: 29.4.3_clz7q7i76oq2x7yxwnubwg6ita
+      ts-jest: 29.0.5_cslgewaznsjxirw6ogkiwclmbu
+      ts-node: 10.9.1_zix2iy4c4a7fivhrc3ey4gy2pu
+      typescript: 4.9.5
+
   packages/component-driver-mui-v5-ui:
     specifiers:
       '@emotion/react': ^11.10.5
@@ -189,7 +211,6 @@ importers:
   packages/playwright:
     specifiers:
       '@playwright/test': ^1.31.1
-      '@testzilla/component-driver-mui-v5': workspace:*
       '@testzilla/core': workspace:*
       '@types/node': ^16.0.0
       jest: ^29.2.0
@@ -200,7 +221,6 @@ importers:
       '@testzilla/core': link:../core
     devDependencies:
       '@playwright/test': 1.31.1
-      '@testzilla/component-driver-mui-v5': link:../component-driver-mui-v5
       '@types/node': 16.18.12
       jest: 29.4.3_ghv2zugsw3zjg5rog5rhyka5ja
       ts-jest: 29.0.5_cslgewaznsjxirw6ogkiwclmbu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #20
* #19
* #18
* #17

This is the 5th to reorganize how each suite of component drivers should be tested, the end result should look like

* component-driver
* component-driver-dom-test
* component-driver-ui
* ~~component-driver-cypress-test~~
* component-driver-playwright-test  (this diff)

This diff moves MUI tests in Playwright to its own package