### PR TITLE
Refactor test organization - Streamline playwright test to use CRA locally (7/n)

### DIFF
--- a/packages/component-driver-mui-v5-test/__tests__/SelectComponentDriver.e2e.test.ts
+++ b/packages/component-driver-mui-v5-test/__tests__/SelectComponentDriver.e2e.test.ts
@@ -1,18 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { SelectComponentDriver } from '@testzilla/component-driver-mui-v5';
 import { createTestEngine } from '@testzilla/playwright'
-import { byDataTestId, ScenePart } from '@testzilla/core';
 import { basicSelectExampleScenePart } from '../src/examples';
 
-const testScenePart = {
-  select: {
-    locator: byDataTestId('demo-simple-select'),
-    driver: SelectComponentDriver,
-  },
-} satisfies ScenePart;
-
 test('happy path selection', async ({ page }) => {
-  await page.goto('http://testzilla-mui-v5.s3-website-us-east-1.amazonaws.com/select');
+  await page.goto('http://localhost:3000/select');
   const testEngine = createTestEngine(page, basicSelectExampleScenePart);
   const targetValue = '30';
   await testEngine.parts.select.setValue(targetValue);

--- a/packages/component-driver-mui-v5-test/playwright.config.ts
+++ b/packages/component-driver-mui-v5-test/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseUrl = 'http://localhost:3000';
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -36,7 +38,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: baseUrl,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -84,8 +86,10 @@ export default defineConfig({
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'cd .. && cd e2e-mui-v5 && pnpm start',
-  //   port: 6066,
-  // },
+  webServer: {
+    command: 'pnpm start',
+    timeout: 120 * 1000,
+    url: baseUrl,
+    reuseExistingServer: true,
+  },
 });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #22

Make Playwright tests to use CRA locally, the helps save the step and cost of deploying the UI to S3.